### PR TITLE
C++ compatibility

### DIFF
--- a/libpsf.c
+++ b/libpsf.c
@@ -49,7 +49,7 @@
 	#endif
 #endif
 
-void psf_open_font(struct psf_font *font, char *fname)
+void psf_open_font(struct psf_font *font, const char *fname)
 {
 	font->psf_fd=(void *)OPEN(fname);
 

--- a/psf.h
+++ b/psf.h
@@ -1,3 +1,7 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #define	PSF_MODE_512		1
 #define	PSF_MODE_HAS_TAB	2
 #define	PSF_MODE_HAS_SEQ	4
@@ -28,7 +32,7 @@ struct psf_font
 	int	psf2_width,psf2_height;
 };
 
-void psf_open_font(struct psf_font *font, char *fname);
+void psf_open_font(struct psf_font *font, const char *fname);
 void psf_read_header(struct psf_font *font);
 int psf_get_glyph_size(struct psf_font *font);
 int psf_get_glyph_height(struct psf_font *font);
@@ -36,3 +40,7 @@ int psf_get_glyph_width(struct psf_font *font);
 int psf_get_glyph_total(struct psf_font *font);
 void psf_read_glyph(struct psf_font *font, void *mem, int size, int fill, int clear);
 void psf_close_font(struct psf_font *font);
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Adds `extern "C"` guards around prototypes and makes `fname` const